### PR TITLE
Adding PAT auth type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,16 @@ CONFLUENCE_USERNAME=your.email@domain.com              # Your Atlassian account 
 CONFLUENCE_API_TOKEN=your_api_token                    # API token for Confluence
 #
 # Jira
-JIRA_URL=https://your-domain.atlassian.net            # Your Jira cloud URL
+JIRA_URL=https://your-domain.atlassian.net            # Your Jira URL (cloud or enterprise)
+JIRA_AUTH_TYPE=api_token                              # Authentication type: 'basic', 'api_token', or 'pat'
+
+# For Cloud (api_token):
 JIRA_USERNAME=your.email@domain.com                   # Your Atlassian account email
-JIRA_API_TOKEN=your_api_token                         # API token for Jira
+JIRA_API_TOKEN=your_api_token                         # API token from id.atlassian.com
+
+# For Enterprise (basic):
+#JIRA_USERNAME=your.username                          # Your Jira username
+#JIRA_PASSWORD=your_password                          # Your Jira password
+
+# For Enterprise (pat):
+#JIRA_PAT=your_personal_access_token                  # Personal Access Token

--- a/src/mcp_atlassian/config.py
+++ b/src/mcp_atlassian/config.py
@@ -15,15 +15,44 @@ class ConfluenceConfig:
         return "atlassian.net" in self.url
 
 
+from enum import Enum
+from typing import Optional
+
+
+class JiraAuthType(Enum):
+    """Supported Jira authentication methods."""
+    BASIC = "basic"  # Username + Password
+    API_TOKEN = "api_token"  # Cloud API Token
+    PAT = "pat"  # Personal Access Token
+
+
 @dataclass
 class JiraConfig:
     """Jira API configuration."""
 
     url: str  # Base URL for Jira
-    username: str  # Email or username
-    api_token: str  # API token used as password
+    auth_type: JiraAuthType  # Authentication method to use
+    username: Optional[str] = None  # Email or username (for BASIC and API_TOKEN)
+    password: Optional[str] = None  # Password (for BASIC auth)
+    api_token: Optional[str] = None  # API token (for cloud)
+    pat: Optional[str] = None  # Personal Access Token (for enterprise)
 
     @property
     def is_cloud(self) -> bool:
         """Check if this is a cloud instance."""
         return "atlassian.net" in self.url
+
+    def validate(self) -> None:
+        """Validate the configuration based on auth type."""
+        if not self.url:
+            raise ValueError("Jira URL is required")
+
+        if self.auth_type == JiraAuthType.BASIC:
+            if not self.username or not self.password:
+                raise ValueError("Username and password are required for basic authentication")
+        elif self.auth_type == JiraAuthType.API_TOKEN:
+            if not self.username or not self.api_token:
+                raise ValueError("Username and API token are required for API token authentication")
+        elif self.auth_type == JiraAuthType.PAT:
+            if not self.pat:
+                raise ValueError("Personal Access Token (PAT) is required for PAT authentication")


### PR DESCRIPTION
This pull request introduces significant changes to the Jira configuration and authentication process, as well as updates to logging and testing. The main changes include adding support for different Jira authentication methods, updating environment variable handling, and improving logging and testing coverage.

### Jira Configuration and Authentication:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL10-R22): Added new environment variables `JIRA_AUTH_TYPE`, `JIRA_PASSWORD`, and `JIRA_PAT` to support different authentication methods for Jira.
* [`src/mcp_atlassian/config.py`](diffhunk://#diff-74192dab15051a741c211d43b3c66bba57999232340d3d4ccba541c9d08bf74dR18-R58): Introduced `JiraAuthType` enum and updated `JiraConfig` to handle different authentication methods. Added validation logic for the configuration.
* [`src/mcp_atlassian/jira.py`](diffhunk://#diff-835eaf18fd72b3698d8da163c6846003f1e76fa866133e8b469e14be551133fbR20-R68): Updated `JiraFetcher` to initialize based on the specified authentication type and validate the configuration. Updated Jira client initialization accordingly.

### Logging Enhancements:

* [`src/mcp_atlassian/server.py`](diffhunk://#diff-5aed7a9c7a1edd4414259c5f03467a28163473241789f3465bcae85d96ef5d41L16-R25): Changed logging level to INFO and added logging for environment variables and service initialization status [[1]](diffhunk://#diff-5aed7a9c7a1edd4414259c5f03467a28163473241789f3465bcae85d96ef5d41L16-R25) [[2]](diffhunk://#diff-5aed7a9c7a1edd4414259c5f03467a28163473241789f3465bcae85d96ef5d41L31-R76).

### Testing Improvements:

* [`tests/test_jira.py`](diffhunk://#diff-c2c4e0ce70f100ecbecc55709647249d209fd59ba025a317627d04afdd536046L11-R17): Added new fixtures for different Jira authentication methods and expanded tests to cover various initialization scenarios and error cases [[1]](diffhunk://#diff-c2c4e0ce70f100ecbecc55709647249d209fd59ba025a317627d04afdd536046L11-R17) [[2]](diffhunk://#diff-c2c4e0ce70f100ecbecc55709647249d209fd59ba025a317627d04afdd536046L25-R55) [[3]](diffhunk://#diff-c2c4e0ce70f100ecbecc55709647249d209fd59ba025a317627d04afdd536046L38-R153) [[4]](diffhunk://#diff-c2c4e0ce70f100ecbecc55709647249d209fd59ba025a317627d04afdd536046L92-R209).